### PR TITLE
Methods of Data::Page accept only scalars.

### DIFF
--- a/lib/Data/Page.pm
+++ b/lib/Data/Page.pm
@@ -23,6 +23,7 @@ sub entries_per_page {
     my $self             = shift;
     my $entries_per_page = $_[0];
     if (@_) {
+        $self->_croak_on_incorrect_number($entries_per_page);
         croak("Fewer than one entry per page!") if $entries_per_page < 1;
         return $self->_entries_per_page_accessor(@_);
     }
@@ -32,7 +33,9 @@ sub entries_per_page {
 sub current_page {
     my $self = shift;
     if (@_) {
-        return $self->_current_page_accessor(@_);
+        my $current_page = $_[0];
+        $self->_croak_on_incorrect_number($current_page);
+        return $self->_current_page_accessor($current_page);
     }
     return $self->first_page unless defined $self->_current_page_accessor;
     return $self->first_page
@@ -45,7 +48,9 @@ sub current_page {
 sub total_entries {
     my $self = shift;
     if (@_) {
-        return $self->_total_entries_accessor(@_);
+        my $total_entries = $_[0];
+        $self->_croak_on_incorrect_number($total_entries);
+        return $self->_total_entries_accessor($_[0]);
     }
     return $self->_total_entries_accessor;
 }
@@ -141,9 +146,27 @@ sub change_entries_per_page {
 
     use integer;
     croak("Fewer than one entry per page!") if $new_epp < 1;
+    $self->_croak_on_incorrect_number($new_epp);
     my $new_page = 1 + ( $self->first / $new_epp );
     $self->entries_per_page($new_epp);
     $self->current_page($new_page);
+}
+
+sub _croak_on_incorrect_number {
+    my ( $self, $maybe_a_number ) = @_;
+
+    # I think that that Data::Page should accept only non-negitive numbers
+    # as parameters to the metods (and fail otherwise). But in the current
+    # tests there is assigning negative numbers and assigning empty string.
+    # So, I assume that this is desired behaviour. And I'm leaving it without
+    # change. This method only test that parameters are simple scalars.
+    #
+    # By the way, if non-negative logic will be implemented here it should be
+    # written as described at http://www.perlmonks.org/?node_id=614452
+
+    if (ref $maybe_a_number ne '') {
+        croak "Expected scalar, but got '$maybe_a_number'";
+    }
 }
 
 1;

--- a/t/incorrect.t
+++ b/t/incorrect.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Test::More;
+use Data::Page;
+
+sub main {
+    my $page = Data::Page->new();
+
+    my $incorrect_number = { aa => 'bb' };
+
+    my $methods = [
+        {
+            name => 'total_entries',
+            default => 0,
+        },
+        {
+            name => 'entries_per_page',
+            default => 0,
+        },
+        {
+            name => 'current_page',
+            default => 0,
+        },
+    ];
+
+    foreach my $method (@{$methods}) {
+        my $name = $method->{name};
+        eval {
+            $page->$name($incorrect_number);
+        };
+
+        like (
+            $@,
+            qr/Expected scalar, but got '/,
+            "Can't use hashref in $method->{name}()"
+        );
+
+        is(
+            $page->total_entries(),
+            $method->{default},
+            "$method->{name}() default is $method->{default}");
+
+    }
+
+    done_testing();
+}
+
+main();


### PR DESCRIPTION
This is a fix that prevent making mistake.

Here is the sample script:

``` perl
my $total_entries = { a => 123 }; # <--- Here is the error! It should be number
my $entries_per_page = 10; 
my $current_page = 1;

my $page = Data::Page->new();
$page->total_entries($total_entries);
$page->entries_per_page($entries_per_page);
$page->current_page($current_page);

print "         First page: ", $page->first_page, "\n";
print "          Last page: ", $page->last_page, "\n";
print "First entry on page: ", $page->first, "\n";
print " Last entry on page: ", $page->last, "\n";
```

It prints something like this:

```
         First page: 1
          Last page: 652424
First entry on page: 1
 Last entry on page: 10
```

The problem is with the last page value.

PS This issue was originally discussed on http://play-perl.org/quest/51278657e8e8478d05000016
